### PR TITLE
fix bug where mobx wouldnt refresh on reference updates

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -70,6 +70,7 @@ class ApiClient implements ApiIface {
     }
 
     async deltaBootstrap(start: Date): Promise<BootstrapData> {
+        start.setSeconds(start.getSeconds() + 1);
         try {
             const objects = await this.request<JsonModel[]>(`/delta-bootstrap?start_time=${encodeURIComponent(start.toISOString())}`);
             return { objects: objects };

--- a/client/src/models/base.ts
+++ b/client/src/models/base.ts
@@ -3,7 +3,6 @@
 import { Change, ObjectPool } from "./pool";
 import { JsonModel } from "../api";
 import { action, makeObservable, observable } from "mobx";
-import { v4 } from "uuid";
 import { localDB } from "./indexdb";
 (Symbol as any).metadata ??= Symbol.for("Symbol.metadata");
 // TODO: Figure out how to polyfill this w/ build system.


### PR DESCRIPTION
To be honest, I don't have a great understanding of why this was needed. The key part here is `o.setProperty(prop, foreignO);` in the foreign relation.